### PR TITLE
fix: incorrect mergify badge, missing netlify badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Playnet
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/0640723c-755e-4561-8161-c581c67dafdc/deploy-status)](https://app.netlify.com/sites/youthful-engelbart-1ad9d2/deploys)
 [![Mergify Status][mergify-status]][mergify]
 
 [mergify]: https://mergify.io
-[mergify-status]: https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/uclaacm/playnet&style=flat
+[mergify-status]: https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/uclaacm/Playnet&style=flat
 
 This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md). By participating, you are 
 expected to uphold this code. Please report unacceptable behavior to acm@ucla.edu.


### PR DESCRIPTION
This PR is a short README adjustment that does two things:

* fixes the URL for the mergify status badge to properly display
* adds a netlify status badge for the project

Closes #15.