### PR TITLE
feat: add hooks to save state to carousel component

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -17,7 +17,7 @@ interface CarouselProps {
 
 function Carousel(props: CarouselProps): JSX.Element {
   const [ slideIdx, setSlideIdx ] = useState(0);
-  let storage = window.sessionStorage;
+  const storage = window.sessionStorage;
 
   useEffect(() => {
     const state = storage.getItem('slideIdx');

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import './styles/Carousel.scss';
 
@@ -17,6 +17,18 @@ interface CarouselProps {
 
 function Carousel(props: CarouselProps): JSX.Element {
   const [ slideIdx, setSlideIdx ] = useState(0);
+  let storage = window.sessionStorage;
+
+  useEffect(() => {
+    const state = storage.getItem('slideIdx');
+    if (state) {
+      setSlideIdx(+state);
+    }
+  }, []);
+
+  useEffect(() => {
+    storage.setItem('slideIdx', slideIdx.toString());
+  }, [slideIdx]);
 
   return (
     <div id={'carousel-wrapper'}>


### PR DESCRIPTION
Save the `slideIdx` to sessionStorage to keep the users state changes in a session.

If they reload the page the state will be saved, but if they delete the session the state will be lost.

I think this is better than doing local storage because:
1. the logic is less complex (no need to set time and check if a time has expired)
2. the solution is simple and fits our need

Fixes: #18 