### PR TITLE
fix: public path fix

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -8,6 +8,7 @@ module.exports = merge(common, {
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].[contenthash].min.js',
+    publicPath: '/',
   },
   module: {
     rules: [


### PR DESCRIPTION
Fix public path, which fixes:
- images for activities not loading properly because routing to wrong pictures
- routing to activities not working properly

It effectively does the same as adding `<base href="/" />` in index.html, but i chose this fix instead so that webpack prod will be more similar to webpack dev