### PR TITLE
fix: button for the intro pages of Activity 2 game

### DIFF
--- a/src/components/styles/Activity1.scss
+++ b/src/components/styles/Activity1.scss
@@ -84,14 +84,13 @@
 }
 
 .game-intro-button {
-  width: 300px;
-  height: 50px;
   max-width: 50%;
   max-height: 50%;
   background-color: #ff5c41;
   color: white;
   font-size: 2vw;
   font-family: inherit;
+  padding: 0.5vw 1vw;
   border-radius: 10px;
   border: none;
   outline: 0;


### PR DESCRIPTION
The buttons for the intro pages of the game of the Activity 2 game had a fixed width and height, so the text would overflow when the screen got larger (i.e. on an external monitor).
I fixed this by changing about 3 lines of code.