### PR TITLE
fix: fix up activity1 intro bubbles

### DIFF
--- a/src/components/Activities/Activity1/TextBubble.tsx
+++ b/src/components/Activities/Activity1/TextBubble.tsx
@@ -12,8 +12,13 @@ interface TextBubbleProps {
 function TextBubble(props: TextBubbleProps): JSX.Element {
   return (
     <div id={props.textBubbleStyle} className='text-bubble'>
-      {(props.contentSvg !== undefined) && <img src={props.contentSvg} className='centered'/>}
-      {(props.text !== undefined) && <span className='centered'>{props.text}</span>}
+      <span className='bubble-contents'>
+        {(props.contentSvg !== undefined) &&
+          <div className='centered'>
+            <img src={props.contentSvg}/>
+          </div>}
+        {(props.text !== undefined) && <div className='centered'>{props.text}</div>}
+      </span>
     </div>
   );
 }

--- a/src/components/styles/TextBubble.scss
+++ b/src/components/styles/TextBubble.scss
@@ -40,6 +40,16 @@
   width: fit-content;
 }
 
+.bubble-contents {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+}
+
 .centered {
   padding: 0 10px 20px;
+  display: grid;
+  place-content: center;
+  position: relative;
+  height: calc(100% - 20px);
 }


### PR DESCRIPTION
- activity1 intro people talking moves around when text bubbles change [see this original](https://deploy-preview-57--play-net.netlify.app/activities/lost-in-translation)
- this commit should fix the absolute & spacing of text bubbles [see this new](https://deploy-preview-58--play-net.netlify.app/activities/lost-in-translation)