### PR TITLE
feat: variance for number reviews and number errors on debug screen

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
 
     '@typescript-eslint/no-require-imports': [ 'error' ],
 
+    '@typescript-eslint/no-non-null-assertion': 'off',
+
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_' }

--- a/src/components/Activities/Activity3/Game/ABTestingReport/Review.tsx
+++ b/src/components/Activities/Activity3/Game/ABTestingReport/Review.tsx
@@ -18,6 +18,12 @@ const reviewer_names = [
   'therealpewdiepie',
   'wdgwth2',
   'captainawesome123',
+  'LegendxForever',
+  'cauliflowerCorn',
+  'xceedz2021',
+  'derpderpderp',
+  'oceanOfTea',
+  'bentoBox24',
 ];
 
 const bugReviews: {[key: number]: string[]} = {
@@ -26,18 +32,21 @@ const bugReviews: {[key: number]: string[]} = {
     'big buggy :(((((((((((((((((((((((',
     '😡😡',
     'Sad face',
+    'what is this list of \'Video could not be found\'......',
   ],
   2: [
     'mmf why it crash',
     'honestly, i could do a better job at this',
     'marginally better than nyan cat',
     'pain 😖',
+    'carash boom',
   ],
   3: [
     'meh',
     'honestly, pretty meh',
-    'meh meh meh',
     'average amount of meh',
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    'its >ALKMMADSFD][  Q;LKLAmkddddddddddddf aww my cat came to find me 🥰',
   ],
   4: [
     'this is pretty cool!',
@@ -268,11 +277,11 @@ function Review(props: ReviewProps): JSX.Element {
 
   return (
     <div>
-      {variableReview && <p>{random(reviewer_names)}: {
+      {variableReview && <p><b>{random(reviewer_names)}:</b> {
         getAVariableReview(variableReview)
       }
       </p>}
-      {isBugReview && <p>{random(reviewer_names)}: {
+      {isBugReview && <p><b>{random(reviewer_names)}:</b> {
         random(bugReviews[stars])
       }
       </p>}

--- a/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
+++ b/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
@@ -63,7 +63,7 @@ function ABTestingReport(): JSX.Element {
     <div className='inline'>
       <div className='half'>
         <h4 style={{ margin: '4px' }}>Reviews</h4>
-        {timeAllocation.abTest != 0 ?
+        {timeAllocation.abTest > 0 ?
           <div style={{ overflowY: 'scroll', maxHeight: '40vh' }}>
             {generateReviews(featureWeights, targetWeights, variableSelection, timeAllocation,
               Math.ceil(timeAllocation.abTest / NUM_ABTEST_DAYS_PER_REVIEW))

--- a/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
+++ b/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
@@ -74,7 +74,7 @@ function ABTestingReport(): JSX.Element {
           : <>You didn&apos;t allocate any days for AB Testing, so you have no reviews.</>}
       </div>
       <div className='half'>
-      <h4 style={{ margin: '4px' }}>Graph</h4>
+        <h4 style={{ margin: '4px' }}>Graph</h4>
         {getABTestingGraph()}
       </div>
     </div>

--- a/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
+++ b/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
@@ -62,25 +62,29 @@ function ABTestingReport(): JSX.Element {
     <h3>A/B Testing: Report</h3>
     <div className='inline'>
       <div className='half'>
-        <h4 style={{ margin: "4px" }}>Reviews</h4>
-        <div style={{ overflowY: "scroll", maxHeight: "40vh" }}>
-          {generateReviews(featureWeights, targetWeights, variableSelection, timeAllocation,
-            Math.ceil(timeAllocation.abTest / NUM_ABTEST_DAYS_PER_REVIEW))
-            .map((props, i) =>
-              <Review key={i} {...props} />)}
-        </div>
+        <h4 style={{ margin: '4px' }}>Reviews</h4>
+        {timeAllocation.abTest != 0 ?
+          <div style={{ overflowY: 'scroll', maxHeight: '40vh' }}>
+            {generateReviews(featureWeights, targetWeights, variableSelection, timeAllocation,
+              Math.ceil(timeAllocation.abTest / NUM_ABTEST_DAYS_PER_REVIEW))
+              .map((props, i) =>
+                <Review key={i} {...props} />)
+            }
+          </div>
+          : <>You didn&apos;t allocate any days for AB Testing, so you have no reviews.</>}
       </div>
       <div className='half'>
+      <h4 style={{ margin: '4px' }}>Graph</h4>
         {getABTestingGraph()}
       </div>
     </div>
     <div>
-      <button className={goBackButtonEnabled ? "playnet-button playnet-btn-blue" : "playnet-button"}
+      <button className={goBackButtonEnabled ? 'playnet-button playnet-btn-blue' : 'playnet-button'}
         onClick={() => setPopup(true)}>
         Submit final product
       </button>
       {
-        goBackButtonEnabled && 
+        goBackButtonEnabled &&
         <button className="playnet-button" onClick={retry}>
           Go back to variables (14 days needed)
         </button>

--- a/src/components/Activities/Activity3/Game/DebuggingResults.tsx
+++ b/src/components/Activities/Activity3/Game/DebuggingResults.tsx
@@ -27,7 +27,7 @@ function DebuggingResults(): JSX.Element {
     setState(A3_GAME_STATE.PriorityWeighing);
   };
 
-  const buttons: { [key: string]: { buttonText: string, onClick: () => void, daysMin: number } } = {
+  const buttons: { [key: string]: { buttonText: string, onClick: () => void, daysMin: number, className?: string } } = {
     'Reduce errors': {
       buttonText: 'Debug (-1 day)',
       onClick: debugADay,
@@ -42,6 +42,7 @@ function DebuggingResults(): JSX.Element {
       buttonText: 'Continue to A/B Testing',
       onClick: goNextState,
       daysMin: -10,
+      className: "playnet-btn-blue",
     },
   };
   return <>
@@ -73,11 +74,11 @@ function DebuggingResults(): JSX.Element {
       <div className='half'>
         <div className='vertical-grid'>
           {
-            Object.entries(buttons).map(([name, { buttonText, onClick, daysMin }]) =>
+            Object.entries(buttons).map(([name, { buttonText, onClick, daysMin, className }]) =>
               <div className='button-group' key={name}>
                 {name}
                 <br />
-                <button className='smaller playnet-button' onClick={onClick}
+                <button className={'smaller playnet-button ' + (className ?? '') } onClick={onClick}
                   disabled={daysMin > daysLeft && daysMin > 0}>
                   {buttonText}
                 </button>

--- a/src/components/Activities/Activity3/Game/DebuggingResults.tsx
+++ b/src/components/Activities/Activity3/Game/DebuggingResults.tsx
@@ -42,7 +42,7 @@ function DebuggingResults(): JSX.Element {
       buttonText: 'Continue to A/B Testing',
       onClick: goNextState,
       daysMin: -10,
-      className: "playnet-btn-blue",
+      className: 'playnet-btn-blue',
     },
   };
   return <>

--- a/src/components/Activities/Activity3/Game/GameConstantsToMessWith.ts
+++ b/src/components/Activities/Activity3/Game/GameConstantsToMessWith.ts
@@ -1,8 +1,8 @@
 /** GRAPH CONSTANTS */
 export const MIN_GRAPH_START = 45;
 export const MAX_GRAPH_START = 70;
-export const SINGLE_CONTROL_CHANGE_MAX = 20;
-export const RANDOM_BETA_TEST_CHANGE = 20;
+export const SINGLE_CONTROL_CHANGE_MAX = 10;
+export const RANDOM_BETA_TEST_CHANGE = 10;
 export const MULTIPLE_FOR_CHANGE_OF_AB_GRAPH = 2;
 export const STABILITY_OF_FINAL = 3; // how many times more stable the final is than the control
 export const FINAL_NUM_POINTS = 20;
@@ -15,9 +15,8 @@ export const MIN_EXPECTED_ALLOCATION = 7;
 
 /** DEBUG CONSTANTS */
 export const MAX_NUM_ERRORS = 10;
-export const DAY_VALUE_FOR_BUILD = 5; // t in an e^-t function, the higher, the less bugs
-// in decimal
-export const EXP_CONSTANT = .02; // the smaller, the more bugs
+export const DEBUG_DAY_VARIANCE = 3;
+export const DEBUG_EXP_CONSTANT = .1; // the smaller, the more bugs
 export const DEBUG_ERROR_OPTIONS = [
   'Image failed to load', 'File not found', 'Unexpected any.', 'Expected linebreaks to be \'LF\' but found \'CRLF\'',
   '\',\' expected.', 'Cannot find name \'numbe\'.', '\'expectedWeights\' is declared but its value is never read.',
@@ -34,8 +33,9 @@ export const NUMBER_TO_QUALITY_MAP = {
 export const QUALITY_DEFAULT_KEY = '1,2';
 
 /** Review Constants */
-export const CHANCE_OF_BUG_REVIEW = .4;
+export const CHANCE_OF_BUG_REVIEW = .3;
 export const STAR_RANDOM_VARIANCE = 1;
+export const NUM_ABTEST_DAYS_PER_REVIEW = 3;
 
 /**
  * Percent when text no longer fits inside final report bar. Note, this is not a pixel value and may not work well for different sized screens

--- a/src/components/Activities/Activity3/Game/gameCalculationsUtil.ts
+++ b/src/components/Activities/Activity3/Game/gameCalculationsUtil.ts
@@ -1,7 +1,7 @@
-import { clamp, random } from '../../../../utils';
+import { clamp, random, randomVariance } from '../../../../utils';
 import {
-  DAY_VALUE_FOR_BUILD, DEBUG_ERROR_OPTIONS,
-  EXP_CONSTANT, FINAL_NUM_POINTS, MAX_GRAPH_START, MAX_NUM_ERRORS, MIN_EXPECTED_ALLOCATION,
+  DEBUG_DAY_VARIANCE, DEBUG_ERROR_OPTIONS,
+  DEBUG_EXP_CONSTANT, FINAL_NUM_POINTS, MAX_GRAPH_START, MAX_NUM_ERRORS, MIN_EXPECTED_ALLOCATION,
   MIN_GRAPH_START, MULTIPLE_FOR_CHANGE_OF_AB_GRAPH, NUMBER_TO_QUALITY_MAP,
   QUALITY_DEFAULT_KEY, RANDOM_BETA_TEST_CHANGE, SINGLE_CONTROL_CHANGE_MAX,
   STABILITY_OF_FINAL,
@@ -66,10 +66,10 @@ export function accuracyOfWeights(
 export function debugQuality(
   daysBuilding: number,
 ): number {
-  const t = daysBuilding * DAY_VALUE_FOR_BUILD;
+  const t = daysBuilding;
   // Use negative exponential to see how many bugs they have. [0, 1] * MAX_NUM_ERRORS
   // e^-x has been chosen because it ranges from [1 - 0]
-  return Math.exp(-1 * EXP_CONSTANT * t);
+  return Math.exp(-1 * DEBUG_EXP_CONSTANT * t);
 }
 
 /**
@@ -98,7 +98,7 @@ export function overallQuality(
 export function getDebugNumErrors(
   daysBuilding: number,
 ): number {
-  const t = debugQuality(daysBuilding);
+  const t = debugQuality(daysBuilding + randomVariance(DEBUG_DAY_VARIANCE));
   const numErrors = Math.floor(MAX_NUM_ERRORS * t);
   return numErrors;
 }
@@ -113,7 +113,7 @@ export function getDebugErrors(
 ): string[] {
   const errors = [];
   for (let i = 0; i < numErrors; i++) {
-    errors.push(random(DEBUG_ERROR_OPTIONS));
+    errors.push(random(DEBUG_ERROR_OPTIONS)!);
   }
   return errors;
 }
@@ -220,7 +220,7 @@ export function getBetaGraph(
   // add numABTestingDays # of points!
   dControlGraph.forEach(({x: controlDx, y: controlDy}) => {
     // find a random change in y based on the quality of the product + control's dy
-    rand = Math.random() * maxChange - (maxChange / 2);
+    rand = randomVariance(maxChange);
     tempDy = MULTIPLE_FOR_CHANGE_OF_AB_GRAPH * (quality - 2.5) + rand;
     tempDyWithControl = tempDy + controlDy;
 

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -21,3 +21,12 @@ export function clamp(min: number, input: number, max: number) : {
 export function objectSum(arr: {[key: string]: number}) : number{
   return Object.values(arr).reduce((prev, curr)=>prev + curr, 0);
 }
+
+/**
+ * Given a number, find a random number between [-num, num], not inclusive
+ * @param num input variance
+ * @returns random number (-num, num)
+ */
+export function randomVariance(num: number) {
+  return 2 * num * (Math.random() - .5);
+}

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -27,6 +27,6 @@ export function objectSum(arr: {[key: string]: number}) : number{
  * @param num input variance
  * @returns random number (-num, num)
  */
-export function randomVariance(num: number) {
+export function randomVariance(num: number): number {
   return 2 * num * (Math.random() - .5);
 }


### PR DESCRIPTION
Hopefully, final logistical act3 game changes
- variance added for debug screen
- add varying number of reviews based on days allocated for abtest
- a bit of moving buttons + other stuff to hopefully psychology kids into going through the game loop
   - blue buttons for continue buttons that they might want to retry instead
   - placed final button on left to let kids avoid pressing it 
   
#206 