### PR TITLE
fix: Fix bug where game 1 in activity 1 will sometimes be stuck at full bar

### DIFF
--- a/src/components/Activities/Activity1/Game1/components/CipherGameRound.tsx
+++ b/src/components/Activities/Activity1/Game1/components/CipherGameRound.tsx
@@ -106,7 +106,7 @@ function CipherGameRound(props: CipherGameRoundProps): JSX.Element {
     if (clickDisabled) return;
     setClickDisabled(true); // block repeated clicks during alien animation
     if (correct) {
-      const newHappiness = Math.min(happiness + CORRECT_PTS, 100); // no overflow
+      const newHappiness = Math.min(happiness + CORRECT_PTS, MAX_HAPPINESS); // no overflow
       const handler = newHappiness === MAX_HAPPINESS ? advanceGame : nextSlide; // prevent no-op by finishing animation before scene change
       setHappiness(newHappiness);
       handleAlienState(ALIEN_STATE.HAPPY, handler);


### PR DESCRIPTION


https://user-images.githubusercontent.com/56695604/120063607-e2b40d00-c01c-11eb-9d4f-c472d9e0aa0e.MOV

The happiness state would sometimes get set to a state greater than the MAX_HAPPINESS value.
The advanceRound detection was based on when happiness === MAX_HAPPINESS, and the Math.min was using 100 instead of MAX_HAPPINESS. This would sometimes cause the happiness to go over MAX_HAPPINESS and the game would be stuck.
I have a video demonstrating the bug attached.

This bug was pretty hard to test, so I'm not sure if I fixed it. From a logically standpoint, I think it is fixed now.