### PR TITLE
feat: fix infinite preload loop, hide day of code tab, other small updates

### DIFF
--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -21,7 +21,7 @@ import './styles/Activities.scss';
 const ACTIVITIES: { [key: string]: string } = {
   'lost-in-translation': 'When you use the search bar, how does YouTube know what you’re looking for?',
   'sending-videos': 'Videos hold a lot of information! How can pages load quickly?',
-  'mind-reading': 'Have you ever wondered how YouTube knows what you want to watch next?',
+  'mind-reading': 'Have you ever why wondered why there are so many programmers and what they are even doing?',
 };
 
 interface ActivityHomeProps {

--- a/src/components/Activities.tsx
+++ b/src/components/Activities.tsx
@@ -21,7 +21,7 @@ import './styles/Activities.scss';
 const ACTIVITIES: { [key: string]: string } = {
   'lost-in-translation': 'When you use the search bar, how does YouTube know what you’re looking for?',
   'sending-videos': 'Videos hold a lot of information! How can pages load quickly?',
-  'mind-reading': 'Have you ever why wondered why there are so many programmers and what they are even doing?',
+  'mind-reading': 'Have you ever wondered why there are so many programmers and what they are even doing?',
 };
 
 interface ActivityHomeProps {

--- a/src/components/Activities/Activity1/index.tsx
+++ b/src/components/Activities/Activity1/index.tsx
@@ -59,6 +59,7 @@ function Activity1(): JSX.Element {
         <TransitionSlide buttonText={'Play Game'}>
           <div>Imagine that you are a computer trying to learn what the alien wants.</div>
           <div>Can you figure out what the alien wants and keep it happy?</div>
+          <p>Note: we don&apos;t know what the alien is saying. We will need to guess!</p>
         </TransitionSlide>,
       showNext: false,
       animationTime: 5.3,
@@ -114,7 +115,7 @@ function Activity1(): JSX.Element {
       child:
         <TransitionSlide buttonText={'Play Game'}>
           <div>But even if we know what the alien is saying... can you figure out what they mean?</div>
-          <div>Warning: One sentence can mean two things, so the answer might not be what you expect!</div>
+          <p>Note: One sentence can mean two things, so we might need to guess!</p>
         </TransitionSlide>,
       showNext: false,
       animationTime: 9.5,

--- a/src/components/Activities/Activity3/Game/ABTestingExplanation.tsx
+++ b/src/components/Activities/Activity3/Game/ABTestingExplanation.tsx
@@ -26,6 +26,7 @@ function ABTestingExplanation(): JSX.Element {
     timeline.current?.add({
       targets: '#abtest-text1',
       ...fadeOut,
+      duration: 500,
     }).add({
       targets: '#abtest-computer2',
       ...fadeIn,

--- a/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
+++ b/src/components/Activities/Activity3/Game/ABTestingReport/index.tsx
@@ -65,7 +65,7 @@ function ABTestingReport(): JSX.Element {
       <div className='half'>
         <h4 style={{ margin: '4px' }}>Reviews</h4>
         {timeAllocation.abTest > 0 ?
-          <div style={{ overflowY: 'scroll', maxHeight: '40vh' }}>
+          <div style={{ overflowY: 'scroll', maxHeight: '40vh', wordWrap: 'break-word' }}>
             {generateReviews(featureWeights, targetWeights, variableSelection, timeAllocation,
               Math.ceil(timeAllocation.abTest / NUM_ABTEST_DAYS_PER_REVIEW))
               .map((props, i) =>

--- a/src/components/Activities/Activity3/Game/DebuggingResults.tsx
+++ b/src/components/Activities/Activity3/Game/DebuggingResults.tsx
@@ -28,7 +28,7 @@ function DebuggingResults(): JSX.Element {
   };
 
   const buttons: { [key: string]: { buttonText: string, onClick: () => void, daysMin: number, className?: string } } = {
-    'Reduce errors': {
+    'Try reducing errors': {
       buttonText: 'Debug (-1 day)',
       onClick: debugADay,
       daysMin: 1,

--- a/src/components/Activities/Activity3/Game/GameConstantsToMessWith.ts
+++ b/src/components/Activities/Activity3/Game/GameConstantsToMessWith.ts
@@ -8,7 +8,7 @@ export const STABILITY_OF_FINAL = 3; // how many times more stable the final is 
 export const FINAL_NUM_POINTS = 20;
 
 /** RATING  CONSTANTS */
-export const WEIGHT_CONSTANT = 15; // the higher, the better the ratings
+export const WEIGHT_CONSTANT = 12; // the higher, the better the ratings
 
 /** Variable Allocation CONSTANTS */
 export const MIN_EXPECTED_ALLOCATION = 7;

--- a/src/components/Activities/Activity3/Game/index.tsx
+++ b/src/components/Activities/Activity3/Game/index.tsx
@@ -192,7 +192,7 @@ function Game(): JSX.Element {
 
   const getABTestingGraph = (isNew?: boolean) => {
     let graph = ABTestingGraph.current;
-    if (timeAllocation.abTest === 0){
+    if (timeAllocation.abTest === 0) {
       graph = undefined;
     } else if (!graph || isNew) {
       const { xyMap, dxyMap } = getABTestingControlGraph(timeAllocation.abTest);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,7 +8,6 @@ import {
 import './styles/App.scss';
 
 import Activities from './Activities';
-import DayOfCode from './DayOfCode';
 import Feedback from './Feedback';
 import Home from './Home';
 import { TAB_INFO } from './shared/PlaynetConstants';
@@ -21,9 +20,9 @@ function App(): JSX.Element {
           {/* A <Switch> looks through its children Routes and
           renders the first one that matches the current URL. */}
           <Switch>
-            <Route path={TAB_INFO.day_of_code.link}>
+            {/* <Route path={TAB_INFO.day_of_code.link}>
               <DayOfCode />
-            </Route>
+            </Route> */}
             <Route path={TAB_INFO.activities.link}>
               <Activities />
             </Route>

--- a/src/components/shared/Carousel.tsx
+++ b/src/components/shared/Carousel.tsx
@@ -192,7 +192,7 @@ function Carousel(props: CarouselProps): JSX.Element {
             <img src={PrevSvg} />
           </button>
           <div id={'carousel-content'} style={{ backgroundColor: `${(child?.showBackground === false) ? 'transparent' : 'white'}` }}>
-            {child.animationTime &&
+            {child.animationTime && !isPreloading &&
               <span className='time-bar-container'>
                 <div key={`${reloadTime}-${slideIdx}`} className='timebar'>
                   <div className='time' style={{ '--time': child.animationTime + 's' } as CSSProperties} />

--- a/src/components/shared/PlaynetConstants.ts
+++ b/src/components/shared/PlaynetConstants.ts
@@ -27,10 +27,10 @@ export const TAB_INFO: { [key in HeaderSections]: { link: string, text: string }
     link: '/feedback',
     text: 'Feedback',
   },
-  [HeaderSections.DAY_OF_CODE]: {
-    link: '/day-of-code',
-    text: 'Day of Code',
-  },
+  // [HeaderSections.DAY_OF_CODE]: {
+  //   link: '/day-of-code',
+  //   text: 'Day of Code',
+  // },
 };
 
 // Internal Constants

--- a/src/components/shared/Preload.tsx
+++ b/src/components/shared/Preload.tsx
@@ -5,6 +5,8 @@ interface PreloadProps {
   images: string[],
   onPreloaded: () => void,
 }
+const PRELOAD_TIMEOUT_IN_SEC = 10;
+
 
 function Preload(props: PreloadProps): JSX.Element {
   const { images } = props;
@@ -12,6 +14,8 @@ function Preload(props: PreloadProps): JSX.Element {
     // void means the promise's result is being ignored.
     // we do this to avoid an eslint rule: @typescript-eslint/no-floating-promises
     void cacheImages(images);
+    const timeout = setTimeout(() => props.onPreloaded(), PRELOAD_TIMEOUT_IN_SEC * 1000);
+    return () => clearTimeout(timeout);
   }, []);
 
   const cacheImages = async (srcArray: Array<string>) => {
@@ -20,8 +24,11 @@ function Preload(props: PreloadProps): JSX.Element {
         const img = new Image();
         img.src = src;
         img.onload = () => resolve(src);
-        img.onerror = () => reject(src);
-      });
+        img.onerror = () => reject(`Could not load ${src}. Please try again.`);
+      }).catch((error) =>
+        // eslint-disable-next-line no-console
+        console.warn(error),
+      );
     });
     await Promise.all(promises);
     props.onPreloaded();

--- a/src/components/styles/Activity3Game.scss
+++ b/src/components/styles/Activity3Game.scss
@@ -96,9 +96,9 @@ $card-height: calc(#{$card-min-width} - 20px);
   width: 100%;
 }
 
-//Selecting variables Tutorial
+// Selecting variables Tutorial
 .enable-blur > * {
-  filter: blur(1.5px) grayscale(0.6) brightness(85%);
+  filter: blur(0.7px) grayscale(0.8) brightness(65%);
 }
 
 .disable-blur {


### PR DESCRIPTION
closes #213 
closes #206 

- tutorial background blur decreased, decided to use grayscale instead
- fixed infinite preload + added timeout
- updated activity 3 activities card to match aim better
- remove day of code tab
- update activity 1 game descriptions to better reflect that we are guessing